### PR TITLE
Восстановлено использование sphinxsearch в github actions

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -30,6 +30,7 @@ jobs:
         run: |
           sudo cp sphinx.conf.ci /etc/sphinxsearch/sphinx.conf
           sudo sed -i 's/START=no/START=yes/g' /etc/default/sphinxsearch
+          sudo systemctl --all --full
           # sudo systemctl start sphinxsearch
           # sudo ls -l /var/log/sphinxsearch
           # sudo ls -l /run

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -4,7 +4,7 @@ on: push
 
 jobs:
   phpunit:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         php: [ '8.1', '8.2' ]
@@ -48,7 +48,6 @@ jobs:
           sudo cat /etc/default/sphinxsearch
           # sudo systemctl list-units
           sudo systemctl status sphinxsearch
-          date
           # sudo ls -l /var/log/sphinxsearch
           # sudo ls -l /run
           # sudo ls -l /tmp

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -4,7 +4,7 @@ on: push
 
 jobs:
   phpunit:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         php: [ '8.1', '8.2' ]
@@ -33,9 +33,9 @@ jobs:
           sudo cp sphinx.conf.ci /etc/sphinxsearch/sphinx.conf
           sudo sed -i 's/START=no/START=yes/g' /etc/default/sphinxsearch
           # sudo cat /etc/default/sphinxsearch
-          sudo systemctl list-units
-          sudo systemctl status sphinxsearch.service
-          sudo systemctl start sphinxsearch.service
+          # sudo systemctl list-units
+          # sudo systemctl status sphinxsearch
+          sudo systemctl start sphinxsearch
           # sudo systemctl status sphinxsearch.service
           # sudo ls -l /var/log/sphinxsearch
           # sudo ls -l /run

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -30,8 +30,8 @@ jobs:
         run: |
           sudo cp sphinx.conf.ci /etc/sphinxsearch/sphinx.conf
           sudo sed -i 's/START=no/START=yes/g' /etc/default/sphinxsearch
-          sudo cat /etc/init.d/sphinxsearch
-          sudo ls -l /var/log
+          sudo systemctl start sphinxsearch
+          sudo ls -l /var/log/sphinxsearch
           sudo searchd --status
           # sudo cat /var/log/sphinxsearch/searchd.log
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -45,6 +45,7 @@ jobs:
           # sudo cat /etc/default/sphinxsearch
           # sudo systemctl list-units
           sudo systemctl status sphinxsearch
+          date
           # sudo ls -l /var/log/sphinxsearch
           # sudo ls -l /run
           # sudo ls -l /tmp

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -32,7 +32,6 @@ jobs:
           sudo sed -i 's/START=no/START=yes/g' /etc/default/sphinxsearch
           sudo systemctl start sphinxsearch
           sudo ls -l /var/log/sphinxsearch
-          sudo searchd --status
           # sudo cat /var/log/sphinxsearch/searchd.log
 
       - name: Create database

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -33,12 +33,13 @@ jobs:
           sudo cat /etc/default/sphinxsearch
           sudo systemctl status sphinxsearch.service
           sudo systemctl start sphinxsearch.service
+          sudo systemctl status sphinxsearch.service
           # sudo ls -l /var/log/sphinxsearch
           # sudo ls -l /run
           # sudo ls -l /tmp
           # sudo ps auxww | grep search
           # sudo cat /var/log/sphinxsearch/searchd.log
-          sudo searchd --status
+          # sudo searchd --status
 
       - name: Create database
         run: |

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -26,24 +26,12 @@ jobs:
         # sudo echo "START=yes\n" > /etc/default/sphinxsearch
         # sudo searchd --status
         # sudo systemctl list-units
-        # sudo systemctl status sphinxsearch.service
+        # sudo systemctl status sphinxsearch
         # cat /etc/default/sphinxsearch
         # cat /etc/init.d/sphinxsearch
         run: |
           sudo cp sphinx.conf.ci /etc/sphinxsearch/sphinx.conf
           sudo sed -i 's/START=no/START=yes/g' /etc/default/sphinxsearch
-
-      - name: Debug sphinxsearch
-        run: |
-          # sudo cat /etc/default/sphinxsearch
-          # sudo systemctl list-units
-          # sudo systemctl status sphinxsearch
-          # sudo systemctl start sphinxsearch
-          sudo ls -l /var/log/sphinxsearch
-          sudo ls -l /run
-          sudo ls -l /tmp
-          sudo ps auxww | grep search
-          # sudo cat /var/log/sphinxsearch/searchd.log
 
       - name: Create database
         run: |
@@ -76,6 +64,19 @@ jobs:
 
       - name: Start sphinxsearch
         run: sudo /etc/init.d/sphinxsearch start
+
+      - name: Debug sphinxsearch
+        run: |
+          cat /etc/init.d/sphinxsearch
+          # sudo cat /etc/default/sphinxsearch
+          # sudo systemctl list-units
+          # sudo systemctl status sphinxsearch
+          # sudo systemctl start sphinxsearch
+          sudo ls -l /var/log/sphinxsearch
+          sudo ls -l /run
+          sudo ls -l /tmp
+          sudo ps auxww | grep search
+          # sudo cat /var/log/sphinxsearch/searchd.log
 
       - name: Prepare Laravel Application
         run: |

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -30,11 +30,11 @@ jobs:
         run: |
           sudo cp sphinx.conf.ci /etc/sphinxsearch/sphinx.conf
           sudo sed -i 's/START=no/START=yes/g' /etc/default/sphinxsearch
-          sudo systemctl start sphinxsearch
+          # sudo systemctl start sphinxsearch
           sudo ls -l /var/log/sphinxsearch
-          sudo ls -l /run
-          sudo ls -l /tmp
-          sudo ps auxww | grep sphinx
+          sudo ls -l /run | grep search
+          sudo ls -l /tmp | grep sphinx
+          sudo ps auxww | grep search
           # sudo cat /var/log/sphinxsearch/searchd.log
 
       - name: Create database

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -32,8 +32,9 @@ jobs:
         run: |
           sudo cp sphinx.conf.ci /etc/sphinxsearch/sphinx.conf
           sudo sed -i 's/START=no/START=yes/g' /etc/default/sphinxsearch
-          sudo cat /etc/default/sphinxsearch
-          # sudo systemctl status sphinxsearch.service
+          # sudo cat /etc/default/sphinxsearch
+          sudo systemctl list-units
+          sudo systemctl status sphinxsearch.service
           sudo systemctl start sphinxsearch.service
           # sudo systemctl status sphinxsearch.service
           # sudo ls -l /var/log/sphinxsearch

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -36,13 +36,11 @@ jobs:
           # sudo systemctl list-units
           # sudo systemctl status sphinxsearch
           # sudo systemctl start sphinxsearch
-          # sudo systemctl status sphinxsearch.service
-          # sudo ls -l /var/log/sphinxsearch
-          # sudo ls -l /run
-          # sudo ls -l /tmp
-          # sudo ps auxww | grep search
+          sudo ls -l /var/log/sphinxsearch
+          sudo ls -l /run
+          sudo ls -l /tmp
+          sudo ps auxww | grep search
           # sudo cat /var/log/sphinxsearch/searchd.log
-          # sudo searchd --status
 
       - name: Create database
         run: |

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -28,6 +28,8 @@ jobs:
         # cat /etc/default/sphinxsearch
         # cat /etc/init.d/sphinxsearch
         run: |
+          sudo cat /usr/share/doc/sphinxsearch/README.Debian
+          sudo cat /etc/sphinxsearch/sphinx.conf
           sudo cp sphinx.conf.ci /etc/sphinxsearch/sphinx.conf
           sudo sed -i 's/START=no/START=yes/g' /etc/default/sphinxsearch
           sudo cat /etc/default/sphinxsearch

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -4,7 +4,7 @@ on: push
 
 jobs:
   phpunit:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         php: [ '8.1', '8.2' ]

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -32,8 +32,8 @@ jobs:
           sudo sed -i 's/START=no/START=yes/g' /etc/default/sphinxsearch
           # sudo systemctl start sphinxsearch
           sudo ls -l /var/log/sphinxsearch
-          sudo ls -l /run | grep search
-          sudo ls -l /tmp | grep sphinx
+          sudo ls -l /run
+          sudo ls -l /tmp
           sudo ps auxww | grep search
           # sudo cat /var/log/sphinxsearch/searchd.log
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -30,8 +30,8 @@ jobs:
         run: |
           sudo cp sphinx.conf.ci /etc/sphinxsearch/sphinx.conf
           sudo sed -i 's/START=no/START=yes/g' /etc/default/sphinxsearch
-          sudo systemctl --all --full
-          # sudo systemctl start sphinxsearch
+          sudo systemctl status sphinxsearch.service
+          sudo systemctl start sphinxsearch.service
           # sudo ls -l /var/log/sphinxsearch
           # sudo ls -l /run
           # sudo ls -l /tmp

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -31,11 +31,12 @@ jobs:
           sudo cp sphinx.conf.ci /etc/sphinxsearch/sphinx.conf
           sudo sed -i 's/START=no/START=yes/g' /etc/default/sphinxsearch
           # sudo systemctl start sphinxsearch
-          sudo ls -l /var/log/sphinxsearch
-          sudo ls -l /run
-          sudo ls -l /tmp
-          sudo ps auxww | grep search
+          # sudo ls -l /var/log/sphinxsearch
+          # sudo ls -l /run
+          # sudo ls -l /tmp
+          # sudo ps auxww | grep search
           # sudo cat /var/log/sphinxsearch/searchd.log
+          sudo searchd --status
 
       - name: Create database
         run: |

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -28,11 +28,10 @@ jobs:
         # cat /etc/default/sphinxsearch
         # cat /etc/init.d/sphinxsearch
         run: |
-          sudo cat /usr/share/doc/sphinxsearch/README.Debian
-          sudo cat /etc/sphinxsearch/sphinx.conf
           sudo cp sphinx.conf.ci /etc/sphinxsearch/sphinx.conf
           sudo sed -i 's/START=no/START=yes/g' /etc/default/sphinxsearch
-          sudo cat /etc/default/sphinxsearch
+          sudo cat /etc/init.d/sphinxsearch
+          sudo ls -l /var/log
           sudo searchd --status
           # sudo cat /var/log/sphinxsearch/searchd.log
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -32,8 +32,8 @@ jobs:
           sudo sed -i 's/START=no/START=yes/g' /etc/default/sphinxsearch
           sudo systemctl start sphinxsearch
           sudo ls -l /var/log/sphinxsearch
+          sudo ls -l /var/run/sphinxsearch
           sudo ls -l /tmp
-          sudo cat /var/log/syslog
           sudo ps auxww | grep sphinx
           # sudo cat /var/log/sphinxsearch/searchd.log
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -32,7 +32,7 @@ jobs:
           sudo sed -i 's/START=no/START=yes/g' /etc/default/sphinxsearch
           sudo systemctl start sphinxsearch
           sudo ls -l /var/log/sphinxsearch
-          sudo ls -l /var/run/sphinxsearch
+          sudo ls -l /var/run
           sudo ls -l /tmp
           sudo ps auxww | grep sphinx
           # sudo cat /var/log/sphinxsearch/searchd.log

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -33,6 +33,7 @@ jobs:
           sudo systemctl start sphinxsearch
           sudo ls -l /var/log/sphinxsearch
           sudo ls -l /tmp
+          sudo cat /var/log/syslog
           sudo ps auxww | grep sphinx
           # sudo cat /var/log/sphinxsearch/searchd.log
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -30,8 +30,9 @@ jobs:
         run: |
           sudo cp sphinx.conf.ci /etc/sphinxsearch/sphinx.conf
           sudo sed -i 's/START=no/START=yes/g' /etc/default/sphinxsearch
-          sudo cat /var/log/sphinxsearch/searchd.log
+          sudo cat /etc/default/sphinxsearch
           sudo searchd --status
+          # sudo cat /var/log/sphinxsearch/searchd.log
 
       - name: Create database
         run: |

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -32,7 +32,7 @@ jobs:
           sudo sed -i 's/START=no/START=yes/g' /etc/default/sphinxsearch
           sudo systemctl start sphinxsearch
           sudo ls -l /var/log/sphinxsearch
-          sudo ls -l /var/run
+          sudo ls -l /run
           sudo ls -l /tmp
           sudo ps auxww | grep sphinx
           # sudo cat /var/log/sphinxsearch/searchd.log

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -41,7 +41,7 @@ jobs:
           cat /etc/init.d/sphinxsearch
           # sudo cat /etc/default/sphinxsearch
           # sudo systemctl list-units
-          # sudo systemctl status sphinxsearch
+          sudo systemctl status sphinxsearch
           # sudo systemctl start sphinxsearch
           # sudo ls -l /var/log/sphinxsearch
           # sudo ls -l /run

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -35,7 +35,7 @@ jobs:
           # sudo cat /etc/default/sphinxsearch
           # sudo systemctl list-units
           # sudo systemctl status sphinxsearch
-          sudo systemctl start sphinxsearch
+          # sudo systemctl start sphinxsearch
           # sudo systemctl status sphinxsearch.service
           # sudo ls -l /var/log/sphinxsearch
           # sudo ls -l /run

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -23,36 +23,23 @@ jobs:
           coverage: none
 
       - name: Setup sphinxsearch
-        # sudo echo "START=yes\n" > /etc/default/sphinxsearch
-        # sudo searchd --status
-        # sudo systemctl list-units
-        # sudo systemctl status sphinxsearch
         # cat /etc/default/sphinxsearch
         # cat /etc/init.d/sphinxsearch
+        # sudo systemctl list-units
+        # sudo systemctl status sphinxsearch
+        # sudo ls -l /var/log/sphinxsearch
+        # sudo ls -l /run
+        # sudo ls -l /tmp
+        # sudo ps auxww | grep searchd
+        # sudo cat /var/log/sphinxsearch/searchd.log
+        # sudo searchd --status
         run: |
           sudo cp sphinx.conf.ci /etc/sphinxsearch/sphinx.conf
           sudo sed -i 's/START=no/START=yes/g' /etc/default/sphinxsearch
 
+      # sphinxsearch-2.2.11-8 на ubuntu-22.04 не запускается
       - name: Start sphinxsearch
         run: sudo /etc/init.d/sphinxsearch start
-
-      - name: Start sphinxsearch via systemctl
-        run: sudo systemctl start sphinxsearch
-
-      - name: Start sphinxsearch via service
-        run: sudo service sphinxsearch start
-
-      - name: Debug sphinxsearch
-        run: |
-          cat /etc/init.d/sphinxsearch
-          sudo cat /etc/default/sphinxsearch
-          # sudo systemctl list-units
-          sudo systemctl status sphinxsearch
-          # sudo ls -l /var/log/sphinxsearch
-          # sudo ls -l /run
-          # sudo ls -l /tmp
-          # sudo ps auxww | grep searchd
-          # sudo cat /var/log/sphinxsearch/searchd.log
 
       - name: Create database
         run: |

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -30,6 +30,8 @@ jobs:
         run: |
           sudo cp sphinx.conf.ci /etc/sphinxsearch/sphinx.conf
           sudo sed -i 's/START=no/START=yes/g' /etc/default/sphinxsearch
+          sudo searchd --status
+          sudo cat /var/log/sphinxsearch/searchd.log
 
       - name: Create database
         run: |

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -30,6 +30,7 @@ jobs:
         run: |
           sudo cp sphinx.conf.ci /etc/sphinxsearch/sphinx.conf
           sudo sed -i 's/START=no/START=yes/g' /etc/default/sphinxsearch
+          sudo cat /etc/default/sphinxsearch
           sudo systemctl status sphinxsearch.service
           sudo systemctl start sphinxsearch.service
           # sudo ls -l /var/log/sphinxsearch

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -4,7 +4,7 @@ on: push
 
 jobs:
   phpunit:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         php: [ '8.1', '8.2' ]

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -43,11 +43,11 @@ jobs:
           # sudo systemctl list-units
           # sudo systemctl status sphinxsearch
           # sudo systemctl start sphinxsearch
-          sudo ls -l /var/log/sphinxsearch
-          sudo ls -l /run
-          sudo ls -l /tmp
-          sudo ps auxww | grep search
-          # sudo cat /var/log/sphinxsearch/searchd.log
+          # sudo ls -l /var/log/sphinxsearch
+          # sudo ls -l /run
+          # sudo ls -l /tmp
+          # sudo ps auxww | grep searchd
+          sudo cat /var/log/sphinxsearch/searchd.log
 
       - name: Create database
         run: |

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -32,6 +32,7 @@ jobs:
           sudo sed -i 's/START=no/START=yes/g' /etc/default/sphinxsearch
           sudo systemctl start sphinxsearch
           sudo ls -l /var/log/sphinxsearch
+          sudo ls -l /tmp
           # sudo cat /var/log/sphinxsearch/searchd.log
 
       - name: Create database

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -25,15 +25,17 @@ jobs:
       - name: Setup sphinxsearch
         # sudo echo "START=yes\n" > /etc/default/sphinxsearch
         # sudo searchd --status
+        # sudo systemctl list-units
+        # sudo systemctl status sphinxsearch.service
         # cat /etc/default/sphinxsearch
         # cat /etc/init.d/sphinxsearch
         run: |
           sudo cp sphinx.conf.ci /etc/sphinxsearch/sphinx.conf
           sudo sed -i 's/START=no/START=yes/g' /etc/default/sphinxsearch
           sudo cat /etc/default/sphinxsearch
-          sudo systemctl status sphinxsearch.service
+          # sudo systemctl status sphinxsearch.service
           sudo systemctl start sphinxsearch.service
-          sudo systemctl status sphinxsearch.service
+          # sudo systemctl status sphinxsearch.service
           # sudo ls -l /var/log/sphinxsearch
           # sudo ls -l /run
           # sudo ls -l /tmp

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -33,6 +33,7 @@ jobs:
           sudo systemctl start sphinxsearch
           sudo ls -l /var/log/sphinxsearch
           sudo ls -l /tmp
+          sudo ps auxww | grep sphinx
           # sudo cat /var/log/sphinxsearch/searchd.log
 
       - name: Create database

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -32,6 +32,9 @@ jobs:
         run: |
           sudo cp sphinx.conf.ci /etc/sphinxsearch/sphinx.conf
           sudo sed -i 's/START=no/START=yes/g' /etc/default/sphinxsearch
+
+      - name: Debug sphinxsearch
+        run: |
           # sudo cat /etc/default/sphinxsearch
           # sudo systemctl list-units
           # sudo systemctl status sphinxsearch

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -33,6 +33,22 @@ jobs:
           sudo cp sphinx.conf.ci /etc/sphinxsearch/sphinx.conf
           sudo sed -i 's/START=no/START=yes/g' /etc/default/sphinxsearch
 
+      - name: Start sphinxsearch
+        run: sudo /etc/init.d/sphinxsearch start
+
+      - name: Debug sphinxsearch
+        run: |
+          cat /etc/init.d/sphinxsearch
+          # sudo cat /etc/default/sphinxsearch
+          # sudo systemctl list-units
+          # sudo systemctl status sphinxsearch
+          # sudo systemctl start sphinxsearch
+          sudo ls -l /var/log/sphinxsearch
+          sudo ls -l /run
+          sudo ls -l /tmp
+          sudo ps auxww | grep search
+          # sudo cat /var/log/sphinxsearch/searchd.log
+
       - name: Create database
         run: |
           sudo systemctl start mysql.service
@@ -61,23 +77,6 @@ jobs:
 
       #- name: Install graphicsmagick
       #  run: sudo apt-get install graphicsmagick
-
-      - name: Start sphinxsearch
-        # run: sudo /etc/init.d/sphinxsearch start
-        run: sudo systemctl start sphinxsearch
-
-      - name: Debug sphinxsearch
-        run: |
-          cat /etc/init.d/sphinxsearch
-          # sudo cat /etc/default/sphinxsearch
-          # sudo systemctl list-units
-          # sudo systemctl status sphinxsearch
-          # sudo systemctl start sphinxsearch
-          sudo ls -l /var/log/sphinxsearch
-          sudo ls -l /run
-          sudo ls -l /tmp
-          sudo ps auxww | grep search
-          # sudo cat /var/log/sphinxsearch/searchd.log
 
       - name: Prepare Laravel Application
         run: |

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -4,7 +4,7 @@ on: push
 
 jobs:
   phpunit:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         php: [ '8.1', '8.2' ]
@@ -47,7 +47,7 @@ jobs:
           # sudo ls -l /run
           # sudo ls -l /tmp
           # sudo ps auxww | grep searchd
-          sudo cat /var/log/sphinxsearch/searchd.log
+          # sudo cat /var/log/sphinxsearch/searchd.log
 
       - name: Create database
         run: |

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -30,8 +30,8 @@ jobs:
         run: |
           sudo cp sphinx.conf.ci /etc/sphinxsearch/sphinx.conf
           sudo sed -i 's/START=no/START=yes/g' /etc/default/sphinxsearch
-          sudo searchd --status
           sudo cat /var/log/sphinxsearch/searchd.log
+          sudo searchd --status
 
       - name: Create database
         run: |

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -39,6 +39,9 @@ jobs:
       - name: Start sphinxsearch via systemctl
         run: sudo systemctl start sphinxsearch
 
+      - name: Start sphinxsearch via service
+        run: sudo service sphinxsearch start
+
       - name: Debug sphinxsearch
         run: |
           cat /etc/init.d/sphinxsearch

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -63,7 +63,8 @@ jobs:
       #  run: sudo apt-get install graphicsmagick
 
       - name: Start sphinxsearch
-        run: sudo /etc/init.d/sphinxsearch start
+        # run: sudo /etc/init.d/sphinxsearch start
+        run: sudo systemctl start sphinxsearch
 
       - name: Debug sphinxsearch
         run: |

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Debug sphinxsearch
         run: |
           cat /etc/init.d/sphinxsearch
-          # sudo cat /etc/default/sphinxsearch
+          sudo cat /etc/default/sphinxsearch
           # sudo systemctl list-units
           sudo systemctl status sphinxsearch
           date

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -36,13 +36,15 @@ jobs:
       - name: Start sphinxsearch
         run: sudo /etc/init.d/sphinxsearch start
 
+      - name: Start sphinxsearch via systemctl
+        run: sudo systemctl start sphinxsearch
+
       - name: Debug sphinxsearch
         run: |
           cat /etc/init.d/sphinxsearch
           # sudo cat /etc/default/sphinxsearch
           # sudo systemctl list-units
           sudo systemctl status sphinxsearch
-          # sudo systemctl start sphinxsearch
           # sudo ls -l /var/log/sphinxsearch
           # sudo ls -l /run
           # sudo ls -l /tmp

--- a/sphinx.conf.ci
+++ b/sphinx.conf.ci
@@ -6,7 +6,7 @@ indexer
 
 searchd
 {
-  listen                 = 127.0.0.1:9312
+  listen                 = 127.0.0.1:9312:sphinx
   listen                 = 127.0.0.1:9306:mysql41
   listen                 = /tmp/sphinx.sock:mysql41
   log                    = /var/log/sphinxsearch/searchd.log

--- a/sphinx.conf.ci
+++ b/sphinx.conf.ci
@@ -6,7 +6,7 @@ indexer
 
 searchd
 {
-  listen                 = 127.0.0.1:9312:sphinx
+  listen                 = 127.0.0.1:9312
   listen                 = 127.0.0.1:9306:mysql41
   listen                 = /tmp/sphinx.sock:mysql41
   log                    = /var/log/sphinxsearch/searchd.log

--- a/sphinx.conf.ci
+++ b/sphinx.conf.ci
@@ -14,7 +14,7 @@ searchd
   query_log_format       = sphinxql
   read_timeout           = 5
   max_children           = 30
-  pid_file               = /var/run/sphinxsearch/searchd.pid
+  pid_file               = /var/run/searchd.pid
   seamless_rotate        = 1
   preopen_indexes        = 1
   unlink_old             = 1

--- a/sphinx.conf.ci
+++ b/sphinx.conf.ci
@@ -14,7 +14,7 @@ searchd
   query_log_format       = sphinxql
   read_timeout           = 5
   max_children           = 30
-  pid_file               = /var/run/sphinxsearch/searchd.pid
+  pid_file               = /run/sphinxsearch/searchd.pid
   seamless_rotate        = 1
   preopen_indexes        = 1
   unlink_old             = 1

--- a/sphinx.conf.ci
+++ b/sphinx.conf.ci
@@ -14,7 +14,7 @@ searchd
   query_log_format       = sphinxql
   read_timeout           = 5
   max_children           = 30
-  pid_file               = /var/run/searchd.pid
+  pid_file               = /var/run/sphinxsearch/searchd.pid
   seamless_rotate        = 1
   preopen_indexes        = 1
   unlink_old             = 1

--- a/sphinx.conf.ci
+++ b/sphinx.conf.ci
@@ -6,8 +6,8 @@ indexer
 
 searchd
 {
-  listen                 = 9312
-  listen                 = 9306:mysql41
+  listen                 = 127.0.0.1:9312
+  listen                 = 127.0.0.1:9306:mysql41
   listen                 = /tmp/sphinx.sock:mysql41
   log                    = /var/log/sphinxsearch/searchd.log
   query_log              = /var/log/sphinxsearch/query.log


### PR DESCRIPTION
На ubuntu 22.04 в данный момент не работает. Вероятно, между версиями sphinxsearch-2.2.11-**2** и 2.2.11-**8** поменялся скрипт `/etc/init.d/sphinxsearch`, что сервис поиска перестал стартовать.